### PR TITLE
pen pressure

### DIFF
--- a/src/plugins/app.ts
+++ b/src/plugins/app.ts
@@ -3,7 +3,7 @@ import _Vue from 'vue';
 
 export class App extends Vue {
   public get version(): string {
-    return '2.2.2';
+    return '2.2.3';
   }
 }
 

--- a/src/views/CanvasRoom/CanvasRoom.vue
+++ b/src/views/CanvasRoom/CanvasRoom.vue
@@ -121,7 +121,7 @@ export default class CanvasRoom extends Vue {
   private brush = {
     color1: '#000000',
     color2: '#ffffff',
-    thickness: 2,
+    thickness: 4,
   };
 
   private currentColorPaletteIds: string[] = [];

--- a/src/views/CanvasRoom/components/CanvasRoomCanvas.vue
+++ b/src/views/CanvasRoom/components/CanvasRoomCanvas.vue
@@ -49,6 +49,7 @@ export default class CanvasRoomCanvas extends Vue {
   private allowDrawOnEnter = false;
 
   private mouseDown = false;
+  private penPressure = 0;
 
   private canvasRef: HTMLCanvasElement | null = null;
 
@@ -142,7 +143,7 @@ export default class CanvasRoomCanvas extends Vue {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }, 100) as any;
 
-    this.canvasRef.addEventListener('mousedown', (e) => {
+    this.canvasRef.addEventListener('pointerdown', (e) => {
       if (this.isMouseInCanvas) {
         this.mouseDown = true;
         if (e.button == 0) {
@@ -163,33 +164,33 @@ export default class CanvasRoomCanvas extends Vue {
         }
 
         this.addToDrawList(
-          new StrokeDrawCommand({ stroke: { x: e.offsetX, y: e.offsetY } })
+          new StrokeDrawCommand({ stroke: { x: e.offsetX, y: e.offsetY, penPressure: this.penPressure } })
         );
       }
     });
 
-    this.canvasRef.addEventListener('mouseup', (e) => {
+    this.canvasRef.addEventListener('pointerup', (e) => {
       this.allowDrawOnEnter = false;
       if (this.mouseDown && this.isMouseInCanvas) {
         this.addToDrawList(
-          new EndStrokeDrawCommand({ stroke: { x: e.offsetX, y: e.offsetY } })
+          new EndStrokeDrawCommand({ stroke: { x: e.offsetX, y: e.offsetY, penPressure: this.penPressure } })
         );
       }
       this.mouseDown = false;
     });
 
-    this.canvasRef.addEventListener('mouseleave', (e) => {
+    this.canvasRef.addEventListener('pointerleave', (e) => {
       this.isMouseInCanvas = false;
       if (this.mouseDown) {
         this.allowDrawOnEnter = true;
         this.mouseDown = false;
         this.addToDrawList(
-          new EndStrokeDrawCommand({ stroke: { x: e.offsetX, y: e.offsetY } })
+          new EndStrokeDrawCommand({ stroke: { x: e.offsetX, y: e.offsetY, penPressure: this.penPressure } })
         );
       }
     });
 
-    this.canvasRef.addEventListener('mouseenter', (e) => {
+    this.canvasRef.addEventListener('pointerenter', (e) => {
       this.isMouseInCanvas = true;
       if (this.allowDrawOnEnter && e.buttons > 0) {
         this.mouseDown = true;
@@ -201,23 +202,35 @@ export default class CanvasRoomCanvas extends Vue {
         );
 
         this.addToDrawList(
-          new StrokeDrawCommand({ stroke: { x: e.offsetX, y: e.offsetY } })
+         new StrokeDrawCommand({ stroke: { x: e.offsetX, y: e.offsetY, penPressure: this.penPressure } })
         );
       }
       this.allowDrawOnEnter = false;
     });
 
-    this.canvasRef.addEventListener('mousemove', (e) => {
+    this.canvasRef.addEventListener('pointermove', (e) => {
       if (!this.canvasRef) return;
 
       this.updateCursor(e.x, e.y);
 
       if (this.mouseDown && this.isMouseInCanvas) {
         this.addToDrawList(
-          new StrokeDrawCommand({ stroke: { x: e.offsetX, y: e.offsetY } })
+          new StrokeDrawCommand({ stroke: { x: e.offsetX, y: e.offsetY, penPressure: this.penPressure } })
         );
       }
     });
+
+    // get pen pressure
+    this.canvasRef.addEventListener('pointermove', (e) => {
+      this.penPressure = e.pressure;
+    });
+
+     // prevent touch controls from scrolling when in contact with the canvas
+    this.canvasRef.addEventListener('touchmove', (e) => {
+      if (!this.canvasRef) return;
+      e.preventDefault();
+    });
+
 
     window.addEventListener('resize', () => {
       // this.setSize();

--- a/src/views/CanvasRoom/components/CanvasRoomDetailsSidebar.vue
+++ b/src/views/CanvasRoom/components/CanvasRoomDetailsSidebar.vue
@@ -7,7 +7,7 @@
       <div class="d-flex align-center">
         <v-card-subtitle style="width: 200px">{{ room.name }} </v-card-subtitle>
         <v-spacer />
-        <div class="d-flex flex-column" margin:auto>
+        <div class="d-flex flex-column" margin:auto style="margin:10px">
           <v-btn small class="mx-1 my-1" @click="createInvite">
             Invite to Room
           </v-btn>

--- a/src/views/CanvasRoom/components/CanvasRoomPaletteSidebarPaletteBoxes.vue
+++ b/src/views/CanvasRoom/components/CanvasRoomPaletteSidebarPaletteBoxes.vue
@@ -131,7 +131,7 @@ export default class CanvasRoomPaletteSidebarPaletteBoxes extends Vue {
     width: 24px;
     height: 24px;
     margin: 1px;
-    border: solid thin rgba(255, 255, 255, 0.315);
+    border: solid thin rgba(255, 255, 255, 0.12);
     border-radius: 7px;
     transform: scale(1);
     transition: all 0.1s ease-out;

--- a/src/views/CanvasRoom/index.ts
+++ b/src/views/CanvasRoom/index.ts
@@ -24,6 +24,7 @@ export interface CanvasSocketEvents {
 export type StrokeSettings = {
   x: number;
   y: number;
+  penPressure: number;
 };
 
 export type CommandName = 'PushBrush' | 'PopBrush' | 'Stroke' | 'EndStroke';
@@ -134,6 +135,7 @@ export class StrokeDrawCommand extends DrawListCommand {
   public stroke: StrokeSettings = {
     x: 0,
     y: 0,
+    penPressure: 0.5,
   };
   public get name(): CommandName {
     return 'Stroke';
@@ -164,7 +166,7 @@ export class StrokeDrawCommand extends DrawListCommand {
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
     ctx.strokeStyle = brush.color;
-    ctx.lineWidth = brush.thickness;
+    ctx.lineWidth = brush.thickness * from.penPressure;
 
     ctx.beginPath();
     ctx.moveTo(from.x, from.y);


### PR DESCRIPTION
- tablet drawing working.
- Pen pressure now automatically set to 1 when using mouse or touch. 
- changed all relevant var names that included "mouse" to "pointer" since they do not always refer to the mouse any more. (example: "mouseDown" becomes "pointerDown")
- minor change to how the cursor position is updated in css. (still works exactly the same, the method of updating the css is altered)
- changed default brush size to 4 (probably pointless since brush size is saved now, i think)
- styling: added margin to invite/leave room button wrapper.